### PR TITLE
Add release script for consistency

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ver=$1
+[[ -z $ver ]] && echo "Please enter a version number." && exit 1
+
+sed -i.bak "s/^__version__ = '[^']*'$/__version__ = '$ver'/g" pdpyras.py setup.py
+vim CHANGELOG.rst
+make docs
+git add CHANGELOG.rst docs/
+git commit -a -m "Version $ver"
+git tag $ver


### PR DESCRIPTION
I forgot to tag a few releases. This script is to make it so I don't have to remember them.

It updates the version number, tags, drops me in an editor with the changelog, then rebuilds docs, commits and tags.