### PR TITLE
Fix formatting issue in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 **2020-02-04: Version 4.0**
 
-* Added support for using OAuth 2 access tokens to authenticate (`#23 <https://github.com/PagerDuty/pdpyras/issues/23>`)
-* Added a property that indicates the access level/scope of a given API credential (`#22 <https://github.com/PagerDuty/pdpyras/issues/22>`)
+* Added support for using OAuth 2 access tokens to authenticate (`#23 <https://github.com/PagerDuty/pdpyras/issues/23>`_)
+* Added a property that indicates the access level/scope of a given API credential (`#22 <https://github.com/PagerDuty/pdpyras/issues/22>`_)
 
 **2020-01-10: version 3.2.1**
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-docs: pdpyras.py README.rst CHANGELOG.rst sphinx/source/index.rst
-	rm -fr ./docs && cd sphinx && make html && cd .. && mv sphinx/build/html ./docs && touch ./docs/.nojekyll
-
-test:
-	./test_pdpyras.py
+%: dist
 
 dist: pdpyras.py setup.py
 	rm -f dist/* && python setup.py sdist
+
+docs/index.html: pdpyras.py README.rst CHANGELOG.rst sphinx/source/index.rst
+	rm -fr ./docs && cd sphinx && make html && cd .. && mv sphinx/build/html ./docs && touch ./docs/.nojekyll
+
+docs: docs/index.html
 
 install: dist
 	python setup.py install 
@@ -16,4 +17,3 @@ testpublish: dist
 publish: dist
 	twine upload dist/*.tar.gz
 
-%: dist

--- a/docs/index.html
+++ b/docs/index.html
@@ -1377,8 +1377,8 @@ would be classified as <code class="docutils literal notranslate"><span class="p
 <h2>Changelog<a class="headerlink" href="#changelog" title="Permalink to this headline">¶</a></h2>
 <p><strong>2020-02-04: Version 4.0</strong></p>
 <ul class="simple">
-<li><p>Added support for using OAuth 2 access tokens to authenticate (<cite>#23 &lt;https://github.com/PagerDuty/pdpyras/issues/23&gt;</cite>)</p></li>
-<li><p>Added a property that indicates the access level/scope of a given API credential (<cite>#22 &lt;https://github.com/PagerDuty/pdpyras/issues/22&gt;</cite>)</p></li>
+<li><p>Added support for using OAuth 2 access tokens to authenticate (<a class="reference external" href="https://github.com/PagerDuty/pdpyras/issues/23">#23</a>)</p></li>
+<li><p>Added a property that indicates the access level/scope of a given API credential (<a class="reference external" href="https://github.com/PagerDuty/pdpyras/issues/22">#22</a>)</p></li>
 </ul>
 <p><strong>2020-01-10: version 3.2.1</strong></p>
 <ul class="simple">


### PR DESCRIPTION
Links didn't render because they were missing a trailing underscore