### PR TITLE
Fix pylint unsupported assignment operation for session.retry[404] = 5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2020-03-08: Version: 4.0.1**
+
+* Only define retry as `{}` once, instead of redefining `None` to `{}` (`#32 <https://github.com/PagerDuty/pdpyras/issues/32>`_)
+
 **2020-02-04: Version 4.0**
 
 * Added support for using OAuth 2 access tokens to authenticate (`#23 <https://github.com/PagerDuty/pdpyras/issues/23>`_)

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -306,7 +306,7 @@ class PDSession(requests.Session):
     upon receiving a HTTP error.
     """
 
-    retry = None
+    retry = {}
     """
     A dict defining the retry behavior for each HTTP response status code.
 
@@ -362,7 +362,6 @@ class PDSession(requests.Session):
             my_name = self.trunc_key
         self.log = logging.getLogger('pdpyras.%s(%s)'%(
             self.__class__.__name__, my_name))
-        self.retry = {}
 
     def after_set_api_key(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '4.0'
+__version__ = '4.0.1'
 
 if __name__ == '__main__':
     setup(


### PR DESCRIPTION
- Only define retry as `{}` once, instead of redefining `None` to `{}` (Fixes: #32).
- Bump version number to `4.0.1`.
