### PR TITLE
Adding parallel calls for iter_all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/.buildinfo
 tmp/
 .DS_Store
 .tool-versions
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**2020-10-21: Version 4.2.2**
+
+* Parallelized the calls to retrieve records for ``iter_all``
+    * Added ``max_threads`` to control the thread count used
+
 **2020-09-15: Version 4.1.2**
 
 * Address issue #37 and add some other small enhancements to `iter_all`:

--- a/README.rst
+++ b/README.rst
@@ -348,11 +348,9 @@ Disclaimers Regarding Iteration
 
 **Regarding Performance:**
 
-Because HTTP requests are made synchronously and not in parallel threads, the
-data will be retrieved one page at a time and the functions ``list_all`` and
-``dict_all`` will not return until after the HTTP response from the final API
-call is received. Simply put, the functions will take longer to return if the
-total number of results is higher.
+As of version 4.2.2, requests are parallelized if there is a need to retrieve
+more than one page of records. A new parameter, ``max_threads``, can be used
+to configure the thread count for your specific environment/needs.
 
 **On Updating and Deleting Records:**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+futures==3.3.0
 requests >= 2.20.0
 backports.unittest_mock ; python_version<"3.0"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '4.1.2'
+__version__ = '4.2.2'
 
 if __name__ == '__main__':
     setup(


### PR DESCRIPTION
When attempting to retrieve all records from an endpoint with a large record set, the `iter_all` function takes a good deal of time while synchronously making the api calls. With this change, all calls after the first request are parallelized to speed things up. A new parameter, `max_threads`, was created to allow for customization for the callers environment/needs. In order to ensure backwards compatibility, we set `max_threads` with a sensible default and we still return an iterator.

**Examples**
Before:
```
>>> print(timeit.timeit(setup="from pdpyras import APISession;p = APISession(<TOKEN>)", stmt="s = list(p.iter_all('services'));print(len(s))", number=1))
1185
12.433564969999992
>>> print(timeit.timeit(setup="from pdpyras import APISession;p = APISession(<TOKEN>)", stmt="s = list(p.iter_all('services'));print(len(s))", number=5))
1185
1185
1185
1185
1185
59.51973305299998
```

After:
```
>>> print(timeit.timeit(setup="from pdpyras import APISession;p = APISession(<TOKEN>)", stmt="list(p.iter_all('services', max_threads=10))", number=1))
3.109743124000005
>>> print(timeit.timeit(setup="from pdpyras import APISession;p = APISession(<TOKEN>)", stmt="s = list(p.iter_all('services', max_threads=8));print(len(s))", number=5))
1185
1185
1185
1185
1185
15.51525755900002
```