### PR TITLE
Add a 5 seconds timeout to all HTTP requests

### DIFF
--- a/pdpyras.py
+++ b/pdpyras.py
@@ -30,6 +30,8 @@ VALID_MULTI_UPDATE_PATHS = [
 
 ITERATION_LIMIT = 1e4
 
+TIMEOUT = 5
+
 #########################
 ### UTILITY FUNCTIONS ###
 #########################
@@ -495,7 +497,7 @@ class PDSession(requests.Session):
         # Merge, but do not replace, any headers specified in keyword arguments:
         if 'headers' in kwargs:
             my_headers.update(kwargs['headers'])
-        req_kw.update({'headers': my_headers, 'stream': False})
+        req_kw.update({'headers': my_headers, 'stream': False, 'timeout': TIMEOUT})
         # Compose/normalize URL whether or not path is already a complete URL
         if url.startswith(self.url) or not self.url:
             my_url = url

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -324,7 +324,7 @@ class APISessionTest(SessionTest):
             headers = headers_get.copy()
             request.assert_called_once_with('GET',
                 'https://api.pagerduty.com/users', headers=headers_get,
-                stream=False)
+                stream=False, timeout=pdpyras.TIMEOUT)
             request.reset_mock()
 
             # Test POST/PUT (in terms of code coverage they're identical)
@@ -332,7 +332,7 @@ class APISessionTest(SessionTest):
             sess.request('post', 'users', json={'user':user})
             request.assert_called_once_with(
                 'POST', 'https://api.pagerduty.com/users',
-                headers=headers_post, json={'user':user}, stream=False)
+                headers=headers_post, json={'user':user}, stream=False, timeout=pdpyras.TIMEOUT)
             request.reset_mock()
 
             # Test GET with parameters and using a HTTP verb method
@@ -342,7 +342,7 @@ class APISessionTest(SessionTest):
             request.assert_called_once_with(
                 'GET', 'https://api.pagerduty.com/users',
                 headers=headers_get, params=user_query, stream=False,
-                allow_redirects=True)
+                allow_redirects=True, timeout=pdpyras.TIMEOUT)
             request.reset_mock()
 
             # Test a POST request with additional headers
@@ -355,7 +355,7 @@ class APISessionTest(SessionTest):
             request.assert_called_once_with('POST',
                 'https://api.pagerduty.com/users/PD6LYSO/future_endpoint',
                 headers=headers_special, json={'user': user}, stream=False,
-                data=None)
+                data=None, timeout=pdpyras.TIMEOUT)
             request.reset_mock()
 
             # Test hitting the rate limit


### PR DESCRIPTION
By default python requests library might hang indefinitely in case of network
issues. See https://requests.readthedocs.io/en/master/user/advanced/#timeouts