### PR TITLE
Catch more generic exceptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 pip: &pip
   name: Install Pip
   command: |
-    sudo apt install python-pip python-virtualenv
+    sudo apt update && sudo apt install python-pip python-virtualenv
 venv: &venv
   name: Setup Virtualenv
   command: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,13 @@
 **2020-09-15: Version 4.1.2**
 
-* Address issue #37 and add some other small enhancements to `iter_all`:
-    * Stop iteration in `iter_all` if the iteration limit (10000) is encountered, versus erroring out (because exceeding it will elicit a 400 response)
-    * Add the ability to set an initial offset via `params` versus always starting from `offset=0` in `iter_all`
+* Address issue #37 and add some other small enhancements to ``iter_all``:
+    * Stop iteration in ``iter_all`` if the iteration limit (10000) is encountered, versus erroring out (because exceeding it will elicit a 400 response)
+    * Add the ability to set an initial offset via ``params`` versus always starting from ``offset=0`` in ``iter_all``
 * Capitalize "constants"
 
 **2020-06-26: Version 4.1.1**
 
-* Define class variable ``retry`` initially as `{}` instead of `None` (`#32 <https://github.com/PagerDuty/pdpyras/issues/32>`_)
+* Define class variable ``retry`` initially as ``{}`` instead of ``None`` (`#32 <https://github.com/PagerDuty/pdpyras/issues/32>`_)
 
 **2020-03-08: Version: 4.1**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1465,9 +1465,9 @@ would be classified as <code class="docutils literal notranslate"><span class="p
 <p><strong>2020-09-15: Version 4.1.2</strong></p>
 <ul class="simple">
 <li><dl class="simple">
-<dt>Address issue #37 and add some other small enhancements to <cite>iter_all</cite>:</dt><dd><ul>
-<li><p>Stop iteration in <cite>iter_all</cite> if the iteration limit (10000) is encountered, versus erroring out (because exceeding it will elicit a 400 response)</p></li>
-<li><p>Add the ability to set an initial offset via <cite>params</cite> versus always starting from <cite>offset=0</cite> in <cite>iter_all</cite></p></li>
+<dt>Address issue #37 and add some other small enhancements to <code class="docutils literal notranslate"><span class="pre">iter_all</span></code>:</dt><dd><ul>
+<li><p>Stop iteration in <code class="docutils literal notranslate"><span class="pre">iter_all</span></code> if the iteration limit (10000) is encountered, versus erroring out (because exceeding it will elicit a 400 response)</p></li>
+<li><p>Add the ability to set an initial offset via <code class="docutils literal notranslate"><span class="pre">params</span></code> versus always starting from <code class="docutils literal notranslate"><span class="pre">offset=0</span></code> in <code class="docutils literal notranslate"><span class="pre">iter_all</span></code></p></li>
 </ul>
 </dd>
 </dl>
@@ -1476,7 +1476,7 @@ would be classified as <code class="docutils literal notranslate"><span class="p
 </ul>
 <p><strong>2020-06-26: Version 4.1.1</strong></p>
 <ul class="simple">
-<li><p>Define class variable <code class="docutils literal notranslate"><span class="pre">retry</span></code> initially as <cite>{}</cite> instead of <cite>None</cite> (<a class="reference external" href="https://github.com/PagerDuty/pdpyras/issues/32">#32</a>)</p></li>
+<li><p>Define class variable <code class="docutils literal notranslate"><span class="pre">retry</span></code> initially as <code class="docutils literal notranslate"><span class="pre">{}</span></code> instead of <code class="docutils literal notranslate"><span class="pre">None</span></code> (<a class="reference external" href="https://github.com/PagerDuty/pdpyras/issues/32">#32</a>)</p></li>
 </ul>
 <p><strong>2020-03-08: Version: 4.1</strong></p>
 <ul class="simple">

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -387,7 +387,7 @@ class APISessionTest(SessionTest):
             with patch.object(pdpyras.time, 'sleep') as sleep:
                 # Test getting a connection error and succeeding the final time.
                 returns = [
-                    pdpyras.Urllib3Error("D'oh!")
+                    pdpyras.HTTPError("D'oh!")
                 ]*sess.max_network_attempts
                 returns.append(Response(200, json.dumps({'user': user})))
                 request.side_effect = returns
@@ -399,10 +399,12 @@ class APISessionTest(SessionTest):
                 request.reset_mock()
                 sleep.reset_mock()
 
-                # Now test handling a non-transient error:
-                raises = [pdpyras.RequestsError("D'oh!")]*(
+                # Now test handling a non-transient error when the client
+                # library itself hits odd issues that it can't handle, i.e.
+                # network:
+                raises = [pdpyras.RequestException("D'oh!")]*(
                     sess.max_network_attempts-1)
-                raises.extend([pdpyras.Urllib3Error("D'oh!")]*2)
+                raises.extend([pdpyras.HTTPError("D'oh!")]*2)
                 request.side_effect = raises
                 self.assertRaises(pdpyras.PDClientError, sess.get, '/users')
                 self.assertEqual(sess.max_network_attempts+1,


### PR DESCRIPTION
This catches all major exception types explicitly defined for `requests` and `urllib3`, including `Timeout`