### PR TITLE
V4.6.0 debug mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -799,9 +799,17 @@ Perform end-to-end publish and installation testing
 
 To test publishing and installing from the package index, first make sure you
 have a valid user account on ``test.pypi.org`` that has publisher access to the
-project as on ``pypi.org``. Then, entering your credentials when prompted, run:
+project as on ``pypi.org``.
 
-... code-block:: shell
+Note, once a release is uploaded, it is no longer possible to upload a release
+with the same version number, even if that release is deleted. For that reason,
+it is a good idea to first add a suffix, i.e. ``-dev001``, to ``__version__``
+in ``setup.py``.
+
+To perform end-to-end tests,  run the following, entering credentials for
+``test.pypi.org`` when prompted:
+
+.. code-block:: shell
 
     make testpublish
 
@@ -812,16 +820,11 @@ The make target ``testpublish`` performs the following:
 * Test-install the library from ``test.pypi.org`` into a temporary Python
   virtualenv that does not already have the library installed, to test
   installing for the first time
-* Tests-installs the library from ``test.pypi.org`` into a temporary Python
+* Tests-install the library from ``test.pypi.org`` into a temporary Python
   virtualenv where the library is already installed, to test upgrading
 
-If any errors are encountered, they should be addressed first before publishing.
-
-To test again, first delete the new release that was previously uploaded:
-
-#. Log in to ``test.pypi.org`` 
-#. Go to https://test.pypi.org/manage/project/pdpyras/releases/
-#. Select "Delete" from the options menu to the right of the new release
+If any errors are encountered, the script should immediately exit. Errors
+should be investigated and mitigated before publishing.
 
 Merge changes and tag
 +++++++++++++++++++++
@@ -829,12 +832,15 @@ Merge changes and tag
 A pull request for releasing a new version should be created, which along with
 the functional changes should also include at least:
 
-* An update to CHANGELOG.rst, where all lines corresponding to community
+* An update to the changelog, where all items corresponding to community
   contributions end with (in parentheses) the GitHub user handle of the
-  contributor, a slash, and a link to the pull request.
+  contributor, a slash, and a link to the pull request (see CHANGELOG.rst for
+  preexisting examples).
 * A change in the version number in both setup.py and pdpyras.py, to a new
   version that follows `Semantic Versioning <https://semver.org/>`_.
 * Rebuilt HTML documentation
+
+
 
 The HTML documentation can be rebuilt with the ``docs`` make target:
 

--- a/README.rst
+++ b/README.rst
@@ -264,8 +264,45 @@ PagerDuty account:
     # PUT the updated list back up to the API
     updated_incidents = session.rput('incidents', json=incidents)
 
-General concepts
-****************
+Logging and debugging
+*********************
+When a session is created, a
+`Logger object <https://docs.python.org/3/library/logging.html#logger-objects>`_
+is created as follows:
+
+* Its level is unconfigured (``logging.NOTSET``) which causes it to defer to the 
+  level of the parent logger, which is the root logger unless specified
+  otherwise (see `Logging Levels
+  <https://docs.python.org/3/library/logging.html#logging-levels>`_).
+* The logger is initially not configured with any handlers. Configuring
+  handlers is left to the discretion of the implementer (see `logging.handlers
+  <https://docs.python.org/3/library/logging.handlers.html>`_)
+* The logger can be accessed through the property :attr:`pdpyras.PDSession.log`.
+  The property is mutable and can be set to a custom logger object.
+
+In version 4.6.0 and later, for debugging and API request troubleshooting, one
+can enable and disable sending log messages to command line output via the
+:attr:`pdpyras.PDSession.debug` property as follows:
+
+.. code-block:: python
+
+    # Method 1: keyword argument, when constructing a new session:
+    session = pdpyras.APISession(api_key, debug=True)
+
+    # Method 2: on an existing session, by setting the property:
+    session.debug = True
+
+    # to disable:
+    session.debug = False
+
+
+What this does is assign a `logging.StreamHandler
+<https://docs.python.org/3/library/logging.handlers.html#streamhandler>`_
+directly to the session's logger and set the log level to debug (``logging.DEBUG``).
+All log messages are then sent directly to ``sys.stderr``.
+
+General API Concepts
+********************
 In all cases, when sending or receiving data through the REST API using
 :class:`pdpyras.APISession`, the following will apply.
 

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -597,21 +597,6 @@ class PDSession(requests.Session):
                 # All went according to plan.
                 return response
 
-    def set_api_key(self, api_key):
-        """
-        (Deprecated) set the API key/token.
-
-        :param api_key:
-            The API key to use
-        :type api_key: str
-        """
-        raise DeprecationWarning("This method is deprecated. Please use the "
-            "object setter directly (i.e. session.api_key = <value>) or "
-            "implement the after_set_api_key method in a child class of "
-            "PDSession to define a hook that runs when the API credential is "
-            "changed.")
-        self.api_key = api_key
-
     @property
     def stagger_cooldown(self):
         """

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -291,13 +291,9 @@ class PDSession(requests.Session):
 
     :param api_key:
         REST API access token to use for HTTP requests
-    :param name:
-        Optional name identifier for logging. If unspecified or ``None``, the
-        last four characters of the REST API token will be used.
     :param debug:
         Sets :attr:`debug`. Set to True to enable verbose command line output.
     :type token: str
-    :type name: str or None
     :type debug: bool
     """
 
@@ -395,12 +391,9 @@ class PDSession(requests.Session):
         self.parent = super(PDSession, self)
         self.parent.__init__()
         self.api_key = api_key
-        if isinstance(name, str) and name:
-            my_name = name
-        else:
-            my_name = self.trunc_key
-        self.log = logging.getLogger('pdpyras.%s(%s)'%(
-            self.__class__.__name__, my_name))
+        if name is not None:
+            raise DeprecationWarning('The "name" parameter is deprecated.')
+        self.log = logging.getLogger(__name__)
         self.debug = debug
         self.retry = {}
 

--- a/publish-test.sh
+++ b/publish-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 refresh_virtualenv () {
     echo "Re-creating temporary virtualenv"
     rm -rf ./tmp

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -20,7 +20,7 @@ import requests
 import sys
 import unittest
 
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import Mock, MagicMock, patch, call
 
 import pdpyras
 
@@ -172,6 +172,31 @@ class APISessionTest(SessionTest):
                 'https://api.pagerduty.com/users/PCWKOPZ/contact_methods'
             )
         )
+
+    def test_debug(self):
+        sess = pdpyras.APISession('token')
+        log = Mock()
+        log.setLevel = Mock()
+        log.addHandler = Mock()
+        sess.log = log
+        sess.debug = True
+        log.setLevel.assert_called_once_with(logging.DEBUG)
+        self.assertEqual(1, len(log.addHandler.call_args_list))
+        self.assertTrue(isinstance(
+            log.addHandler.call_args_list[0][0][0],
+            logging.StreamHandler
+        ))
+        log.setLevel.reset_mock()
+        log.removeHandler = Mock()
+        sess.debug = False
+        log.setLevel.assert_called_once_with(logging.NOTSET)
+        self.assertEqual(1, len(log.removeHandler.call_args_list))
+        self.assertTrue(isinstance(
+            log.removeHandler.call_args_list[0][0][0],
+            logging.StreamHandler
+        ))
+        sess = pdpyras.APISession('token', debug=True)
+        self.assertTrue(isinstance(sess._debugHandler, logging.StreamHandler))
 
     @patch.object(pdpyras.APISession, 'iter_all')
     def test_find(self, iter_all):


### PR DESCRIPTION
In this version:

* A long-deprecated method has been removed
* New "debug mode" which sends logging statements to stderr