### PR TITLE
Fix unsupported format character 'B'

### DIFF
--- a/pdpyras.py
+++ b/pdpyras.py
@@ -785,9 +785,9 @@ def http_error_message(r: requests.Response, context=None):
         return f"{endpoint}: Network or other unknown error{context_msg}"
     else:
         return (
-            f"{endpoint}: Success (status %d) but an expectation still " \
+            f"{endpoint}: Success (status {r.status_code}) but an expectation still " \
             f"failed{context_msg}"
-        )%(r.status_code)
+        )
 
 def last_4(secret: str):
     """Returns an abbreviation of the input"""


### PR DESCRIPTION
I get this error : `ValueError: unsupported format character 'B' (0x42) at index 61`

Stacktrace :
```
File .venv/lib/python3.11/site-packages/pdpyras.py:1849, in APISession.iter_all(self, url, params, paginate, page_size, item_hook, total)
   1846     return
   1848 # Make the request and validate/unpack the response:
-> 1849 r = successful_response(
   1850     self.get(url, params=data.copy()),
   1851     context='classic pagination'
   1852 )
   1853 body = try_decoding(r)
   1854 results = unwrap(r, wrapper)

File .venv/lib/python3.11/site-packages/pdpyras.py:859, in successful_response(r, context)
    847 def successful_response(r: requests.Response, context=None) \
    848         -> requests.Response:
    849     """Validates the response as successful.
    850 
    851     Returns the response if it was successful; otherwise, raises an exception.
   (...)
    857     :returns: The response object, if it was successful
    858     """
--> 859     message = http_error_message(r, context=context)
...
    788         f"{endpoint}: Success (status %d) but an expectation still " \
    789         f"failed{context_msg}"
    790     )%(r.status_code)

ValueError: unsupported format character 'B' (0x42) at index 61
```

The actual code mix f-string and %d.
This occurs the `ValueError`.
I just change the code to use f-string.