### PR TITLE
V5.0.3 log and error message fixes

### DIFF
--- a/pdpyras.py
+++ b/pdpyras.py
@@ -1194,11 +1194,14 @@ class PDSession(requests.Session):
                     # Retry a specific number of times (-1 implies infinite)
                     if http_attempts.get(status, 0)>=retry_logic or \
                             sum(http_attempts.values())>self.max_http_attempts:
+                        lower_limit = retry_logic
+                        if lower_limit > self.max_http_attempts:
+                            lower_limit = self.max_http_attempts
                         self.log.error(
                             f"%s: Non-transient HTTP error: exceeded " \
                             'maximum number of attempts (%d) to make a ' \
                             'successful request. Currently encountering ' \
-                            'status %d.', endpoint, self.retry[status], status)
+                            'status %d.', endpoint, lower_limit, status)
                         return response
                     http_attempts[status] = 1 + http_attempts.get(status, 0)
                 sleep_timer *= self.cooldown_factor()

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -853,15 +853,14 @@ def successful_response(r: requests.Response, context=None) \
         A description of when the HTTP request is happening, for error reporting
     :returns: The response object, if it was successful
     """
-    message = http_error_message(r, context=context)
     if r.ok and bool(r.status_code):
         return r
     elif r.status_code / 100 == 5:
-        raise PDServerError(message, r)
+        raise PDServerError(http_error_message(r, context=context), r)
     elif bool(r.status_code):
-        raise PDHTTPError(message, r)
+        raise PDHTTPError(http_error_message(r, context=context), r)
     else:
-        raise PDClientError(message)
+        raise PDClientError(http_error_message(r, context=context))
 
 def truncate_text(text: str):
     """Truncates a string longer than :attr:`TEXT_LEN_LIMIT`

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -612,19 +612,19 @@ def unwrap(response: requests.Response, wrapper):
         # There is a wrapped entity to unpack:
         bod_type = type(body)
         error_msg = f"Expected response body from {endpoint} after JSON-" \
-            f"decoding to be a dictionary with a key \"{wrapper}\", but %s."
+            f"decoding to be a dictionary with a key \"{wrapper}\", but "
         if bod_type is dict:
             if wrapper in body:
                 return body[wrapper]
             else:
                 keys = truncate_text(', '.join(body.keys()))
                 raise PDServerError(
-                    error_msg%(f"its keys are: {keys}",),
+                    error_msg + f"its keys are: {keys}",
                     response
                 )
         else:
             raise PDServerError(
-                error_msg%(f"its type is {bod_type}.",),
+                error_msg + f"its type is {bod_type}.",
                 response
             )
     else:
@@ -777,17 +777,14 @@ def http_error_message(r: requests.Response, context=None):
             err_type = 'client'
         elif r.status_code / 100 == 5:
             err_type = 'server'
-        return (
-            f"{endpoint}: API responded with {err_type} error (status %d)" \
-            f"{context_msg}: %s"
-        ) % (r.status_code, truncate_text(r.text))
+        tr_bod = truncate_text(r.text)
+        return f"{endpoint}: API responded with {err_type} error (status " \
+            f"{r.status_code}){context_msg}: {tr_bod}"
     elif not received_http_response:
         return f"{endpoint}: Network or other unknown error{context_msg}"
     else:
-        return (
-            f"{endpoint}: Success (status {r.status_code}) but an expectation still " \
-            f"failed{context_msg}"
-        )
+        return f"{endpoint}: Success (status {r.status_code}) but an " \
+            f"expectation still failed{context_msg}"
 
 def last_4(secret: str):
     """Returns an abbreviation of the input"""
@@ -1152,9 +1149,9 @@ class PDSession(requests.Session):
         http_attempts = {}
         method = method.strip().upper()
         if method not in self.permitted_methods:
-            raise PDClientError(
-                "Method %s not supported by this API. Permitted methods: %s"%(
-                    method, ', '.join(self.permitted_methods)))
+            m_str = ', '.join(self.permitted_methods)
+            raise PDClientError(f"Method {method} not supported by this API. " \
+                f"Permitted methods: {m_str}")
         req_kw = deepcopy(kwargs)
         full_url = self.normalize_url(url)
         endpoint = "%s %s"%(method.upper(), full_url)
@@ -1179,10 +1176,9 @@ class PDSession(requests.Session):
             except (HTTPError, PoolError, RequestException) as e:
                 network_attempts += 1
                 if network_attempts > self.max_network_attempts:
-                    raise PDClientError(
-                        (f"{endpoint}: Non-transient network error; exceeded " \
-                        'maximum number of attempts (%d) to connect to the ' \
-                        'API.')%self.max_network_attempts
+                    raise PDClientError(f"{endpoint}: Non-transient network " \
+                        'error; exceeded maximum number of attempts ' \
+                        f"({self.max_network_attempts}) to connect to the API.")
                     )
                 sleep_timer *= self.cooldown_factor()
                 self.log.warning(
@@ -1200,10 +1196,10 @@ class PDSession(requests.Session):
                     if http_attempts.get(status, 0)>=retry_logic or \
                             sum(http_attempts.values())>self.max_http_attempts:
                         self.log.error(
-                            f"{endpoint}: Non-transient HTTP error: exceeded " \
+                            f"%s: Non-transient HTTP error: exceeded " \
                             'maximum number of attempts (%d) to make a ' \
                             'successful request. Currently encountering ' \
-                            'status %d.', self.retry[status], status)
+                            'status %d.', endpoint, self.retry[status], status)
                         return response
                     http_attempts[status] = 1 + http_attempts.get(status, 0)
                 sleep_timer *= self.cooldown_factor()

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -1178,7 +1178,6 @@ class PDSession(requests.Session):
                     raise PDClientError(f"{endpoint}: Non-transient network " \
                         'error; exceeded maximum number of attempts ' \
                         f"({self.max_network_attempts}) to connect to the API.")
-                    )
                 sleep_timer *= self.cooldown_factor()
                 self.log.warning(
                     "%s: HTTP or network error: %s. retrying in %g seconds.",

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -18,7 +18,7 @@ from deprecation import deprecated, DeprecatedWarning
 from urllib3.exceptions import HTTPError, PoolError
 from requests.exceptions import RequestException
 
-__version__ = '5.0.2'
+__version__ = '5.0.3'
 
 #######################
 ### CLIENT DEFAULTS ###

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '5.0.2'
+__version__ = '5.0.3'
 
 if __name__ == '__main__':
     setup(

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -506,7 +506,8 @@ class APISessionTest(SessionTest):
             Response(200, json.dumps(page(1, 30, 10))),
             Response(200, json.dumps(page(2, 30, 10))),
         ]
-        weirdurl='https://api.pagerduty.com/users?number=1'
+        # Follow-up to #103: add more odd parameters to the URL
+        weirdurl='https://api.pagerduty.com/users?number=1&filters[]=foo'
         hook = MagicMock()
         items = list(sess.iter_all(weirdurl, item_hook=hook, total=True, page_size=10))
         self.assertEqual(3, get.call_count)


### PR DESCRIPTION
This is the more generic fix for #102 that eliminates all unsafe mixing of f-string and printf-style string formatting. This was becoming a problem because the pre-formatted strings were getting full unescaped URLs interpolated into them, which included the `%` character, causing Python to interpret URL character entities as format characters.