### PR TITLE
Handle exact path matches

### DIFF
--- a/pdpyras.py
+++ b/pdpyras.py
@@ -421,10 +421,16 @@ def canonical_path(base_url: str, url: str):
             patterns
         ))
         # Don't break early if len(patterns) == 1, but require an exact match...
+
     if len(patterns) == 0:
         raise URLError(f"URL {url} does not match any canonical API path " \
             'supported by this client.')
     elif len(patterns) > 1:
+        # If there's multiple matches but one matches exactly, return that.
+        if url_path in patterns:
+            return url_path
+
+        # ...otherwise this is ambiguous.
         raise Exception(f"Ambiguous URL {url} matches more than one " \
             "canonical path pattern: "+', '.join(patterns)+'; this is likely ' \
             'a bug.')


### PR DESCRIPTION
This PR fixes the handling of exact path matches by checking if the requested path is an exact match for any of the patterns when more than 1 pattern matches.

For example, before this PR, a request for `/users/me` fails due to matching multiple paths:-

```python
Exception: Ambiguous URL /users/me matches more than one canonical path pattern: /users/{id}, /users/me; 
  this is likely a bug.
```

After this PR, it works as expected:-

```python
{
│   'name': 'Andy Smith',
│   'email': 'asmith@pagerduty.com',
│   'time_zone': 'America/Denver',
...
}
```