### PR TITLE
Add Python 3.12 and 3.13 to CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,35 @@ jobs:
       - run:
           <<: *test
 
-workflows: 
+  py3_12:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run:
+          <<: *venv
+      - run:
+          <<: *getenv
+      - run:
+          <<: *depinst
+      - run:
+          <<: *test
+
+  py3_13:
+    docker:
+      - image: cimg/python:3.13
+    steps:
+      - checkout
+      - run:
+          <<: *venv
+      - run:
+          <<: *getenv
+      - run:
+          <<: *depinst
+      - run:
+          <<: *test
+
+workflows:
   version: 2.1
   run_tests:
     jobs:
@@ -119,4 +147,6 @@ workflows:
       - py3_9
       - py3_10
       - py3_11
+      - py3_12
+      - py3_13
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ manipulated through APIs are left to the user or implementer to make.
 Features
 --------
 - Uses Requests' automatic HTTP connection pooling and persistence
-- Tested in / support for Python 3.6 through 3.11
+- Tested in / support for Python 3.6 through 3.13
 - Abstraction layer for authentication, pagination, filtering and wrapped
   entities
 - Configurable cooldown/reattempt logic for handling rate limiting and


### PR DESCRIPTION
Python 3.12 and 3.13 were released last year and this year, respectively. It would be nice if pdpyras runs test suites with newer Python version on CI.