### PR TITLE
v6.0.0 Replace Requests with HTTPX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,6 @@ test: &test
 
 jobs:
 
-  py3_6:
-    docker:
-      - image: cimg/python:3.6
-    steps:
-      - checkout
-      - run:
-          <<: *test
-
-  py3_7:
-    docker:
-      - image: cimg/python:3.7
-    steps:
-      - checkout
-      - run:
-          <<: *test
-
   py3_8:
     docker:
       - image: cimg/python:3.8
@@ -82,8 +66,6 @@ workflows:
   version: 2.1
   run_tests:
     jobs:
-      - py3_6
-      - py3_7
       - py3_8
       - py3_9
       - py3_10

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,7 +117,7 @@ Note: version 5.0.0 has been yanked; patch release v5.0.1 addresses an issue in 
 
 * Use documented method for including the routing key in the request for API V2 (addresses `#53 <https://github.com/PagerDuty/pdpyras/issues/53>`_)
 * Add warning for Python 2.7
-* Configurable timeout: argument to ``httpx.Client.request`` set in default args to backwards-compatible 5 second value that can be set at the module level (@ctrlaltdel / `#48 <https://github.com/PagerDuty/pdpyras/pull/48>`_)
+* Configurable timeout: argument to ``requests.Session.request`` set in default args to backwards-compatible 5 second value that can be set at the module level (@ctrlaltdel / `#48 <https://github.com/PagerDuty/pdpyras/pull/48>`_)
 
 **2020-09-15: Version 4.1.2**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,7 +117,7 @@ Note: version 5.0.0 has been yanked; patch release v5.0.1 addresses an issue in 
 
 * Use documented method for including the routing key in the request for API V2 (addresses `#53 <https://github.com/PagerDuty/pdpyras/issues/53>`_)
 * Add warning for Python 2.7
-* Configurable timeout: argument to ``requests.Session.request`` set in default args to backwards-compatible 5 second value that can be set at the module level (@ctrlaltdel / `#48 <https://github.com/PagerDuty/pdpyras/pull/48>`_)
+* Configurable timeout: argument to ``httpx.Client.request`` set in default args to backwards-compatible 5 second value that can be set at the module level (@ctrlaltdel / `#48 <https://github.com/PagerDuty/pdpyras/pull/48>`_)
 
 **2020-09-15: Version 4.1.2**
 

--- a/README.rst
+++ b/README.rst
@@ -29,10 +29,9 @@ into the API, using basic Python types (``dict``, ``list``, ``str`` and
 
 Features
 --------
-- Uses HTTPX's automatic HTTP connection pooling and persistence
-- Tested in / support for Python 3.6 through 3.13
-- Abstraction layer for authentication, pagination, filtering and wrapped
-  entities
+- Automatic HTTP connection pooling and persistence
+- Tested in / support for Python 3.8 through 3.13
+- Abstractions for authentication, pagination and entity wrapping
 - Configurable cooldown/reattempt logic for handling rate limiting and
   transient HTTP or network issues
 
@@ -40,17 +39,17 @@ History
 -------
 This module was borne of necessity for a basic API client to eliminate code
 duplication in some of the PagerDuty Customer Support team's internal
-Python-based API tooling.
+Python-based API tooling. We needed something to eliminate the toil of
+re-implementing common solutions such as querying objects by name, pagination
+and authentication.
 
-We found ourselves frequently performing REST API requests using beta or
+We also found ourselves frequently performing REST API requests using beta or
 non-documented API endpoints for one reason or another, so we needed the client
 that provided easy access to features of the underlying HTTP library (i.e. to
-obtain the response headers, or set special request headers). We also needed
-something that eliminated tedious tasks like querying objects by name,
-pagination and authentication. Finally, we discovered that the way we were
-using Requests (our erstwhile go-to HTTP client) wasn't leveraging its
-connection pooling feature, and wanted a way to easily enforce this as a
-standard practice.
+obtain the response headers, or set special request headers). Finally, we
+discovered that the way we were using Requests (our erstwhile go-to HTTP
+client) wasn't leveraging its connection pooling feature, which led to
+performance issues, and we wanted a way to easily enforce best practices.
 
 We evaluated at the time a few other open-source API libraries and deemed them
 to be either overkill for our purposes or not giving the implementer enough

--- a/README.rst
+++ b/README.rst
@@ -10,18 +10,26 @@ For how-to, refer to the `User Guide
 
 Overview
 --------
-This library supplies classes extending `requests.Session`_ from the Requests_
+This library supplies classes extending `httpx.Client`_ from the HTTPX_
 HTTP library that serve as Python interfaces to the `REST API v2`_ and `Events
 API v2`_ of PagerDuty. One might call it an opinionated wrapper library. It was
-designed with the philosophy that Requests_ is a perfectly adequate HTTP
-client, and that abstraction should focus only on the most generally applicable
-and frequently-implemented core features, requirements and tasks. Design
-decisions concerning how any particular PagerDuty resource is accessed or
-manipulated through APIs are left to the user or implementer to make.
+designed based on these tenets:
+
+- The client should not reinvent the wheel when it comes to HTTP.
+- A successful API client should emphasize abstractions for only the most
+  broadly-applicable and frequently-implemented core patterns and requirements
+  of the API(s) that it was built to access.
+
+Decisions concerning how any particular PagerDuty resource is handled, and
+which API calls are made to accomplish a design goal, are left to the end user
+("implementer") to make. This client's focus is on removing barriers to getting
+the API's data into the hands of the implementer, and the implementer's data
+into the API, using basic Python types (``dict``, ``list``, ``str`` and
+``int``) to represent the data.
 
 Features
 --------
-- Uses Requests' automatic HTTP connection pooling and persistence
+- Uses HTTPX's automatic HTTP connection pooling and persistence
 - Tested in / support for Python 3.6 through 3.13
 - Abstraction layer for authentication, pagination, filtering and wrapped
   entities
@@ -31,7 +39,8 @@ Features
 History
 -------
 This module was borne of necessity for a basic API client to eliminate code
-duplication in some of PagerDuty Support's internal Python-based API tooling.
+duplication in some of the PagerDuty Customer Support team's internal
+Python-based API tooling.
 
 We found ourselves frequently performing REST API requests using beta or
 non-documented API endpoints for one reason or another, so we needed the client
@@ -39,8 +48,9 @@ that provided easy access to features of the underlying HTTP library (i.e. to
 obtain the response headers, or set special request headers). We also needed
 something that eliminated tedious tasks like querying objects by name,
 pagination and authentication. Finally, we discovered that the way we were
-using `Requests`_ wasn't making use of its connection pooling feature, and
-wanted a way to easily enforce this as a standard practice.
+using Requests (our erstwhile go-to HTTP client) wasn't leveraging its
+connection pooling feature, and wanted a way to easily enforce this as a
+standard practice.
 
 We evaluated at the time a few other open-source API libraries and deemed them
 to be either overkill for our purposes or not giving the implementer enough
@@ -84,14 +94,17 @@ Warranty
 .. References:
 .. -----------
 
-.. _`Requests`: https://docs.python-requests.org/en/master/
-.. _`Errors`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTYz-errors
-.. _`Events API v2`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgw-events-api-v2-overview
+.. _`HTTPX`: https://www.python-httpx.org/
+.. _`Errors`: https://developer.pagerduty.com/docs/cd9f75aa7ac93-errors
+.. _`Events API v2`: https://developer.pagerduty.com/docs/3d063fd4814a6-events-api-v2-overview
 .. _`PagerDuty API Reference`: https://developer.pagerduty.com/api-reference/
-.. _`REST API v2`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTUw-rest-api-v2-overview
+.. _`REST API v2`: https://developer.pagerduty.com/docs/531092d4c6658-rest-api-v2-overview
 .. _`setuptools`: https://pypi.org/project/setuptools/
-.. _requests.Response: https://docs.python-requests.org/en/master/api/#requests.Response
-.. _requests.Session: https://docs.python-requests.org/en/master/api/#request-sessions
+.. _httpx.Response: https://www.python-httpx.org/api/#response
+.. _httpx.Session: https://www.python-httpx.org/api/#client
 
 .. |circleci-build| image:: https://circleci.com/gh/PagerDuty/pdpyras.svg?style=svg
     :target: https://circleci.com/gh/PagerDuty/pdpyras
+
+.. role:: strike
+  :class: strike

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -13,12 +13,10 @@ from typing import Iterator, Union
 from warnings import warn
 
 # Upstream components on which this client is based:
-from httpx import Response, Client
+from httpx import Client, RequestError, Response
 from httpx import __version__ as HTTPX_VERSION
 
 # HTTP client exceptions:
-from urllib3.exceptions import HTTPError, PoolError
-from requests.exceptions import RequestException
 
 __version__ = '5.3.0'
 
@@ -1149,10 +1147,10 @@ class PDSession(Client):
             try:
                 response = self.parent.request(method, full_url, **req_kw)
                 self.postprocess(response)
-            except (HTTPError, PoolError, RequestException) as e:
+            except RequestError as e:
                 network_attempts += 1
                 if network_attempts > self.max_network_attempts:
-                    error_msg = f"{endpoint}: Non-transient network " \
+                    error_msg = f"{endpoint}: Non-transient network or transport " \
                         'error; exceeded maximum number of attempts ' \
                         f"({self.max_network_attempts}) to connect to the API."
                     raise PDClientError(error_msg) from e

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -18,7 +18,7 @@ from httpx import __version__ as HTTPX_VERSION
 
 # HTTP client exceptions:
 
-__version__ = '5.3.0'
+__version__ = '6.0.0'
 
 #######################
 ### CLIENT DEFAULTS ###

--- a/pdpyras.py
+++ b/pdpyras.py
@@ -957,7 +957,7 @@ class PDSession(Client):
 
     timeout = TIMEOUT
     """
-    This is the value sent to `Requests`_ as the ``timeout`` parameter that
+    This is the value sent to `HTTPX`_ as the ``timeout`` parameter that
     determines the TCP read timeout.
     """
 
@@ -1134,7 +1134,6 @@ class PDSession(Client):
         # Add in any headers specified in keyword arguments:
         headers = kwargs.get('headers', {})
         req_kw.update({
-            'stream': False,
             'timeout': self.timeout
         })
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests >= 2.27.1
-deprecation >= 2.0.6
+httpx >= 0.27

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '5.3.0'
+__version__ = '6.0.0'
 
 if __name__ == '__main__':
     setup(

--- a/sphinx/source/module_reference.rst
+++ b/sphinx/source/module_reference.rst
@@ -62,7 +62,7 @@ Functions that implement entity wrapping logic.
 Function Decorators
 *******************
 Intended for use with functions based on the HTTP verb functions of subclasses
-of `requests.Session`_, i.e. that would otherwise return a `requests.Response`_
+of `httpx.Client`_, i.e. that would otherwise return a `httpx.Response`_
 object.
 
 .. automodule:: pdpyras
@@ -80,6 +80,6 @@ Miscellaneous functions
 .. References:
 .. -----------
 
-.. _`Requests`: https://docs.python-requests.org/en/master/
-.. _requests.Response: https://docs.python-requests.org/en/master/api/#requests.Response
-.. _requests.Session: https://docs.python-requests.org/en/master/api/#request-sessions
+.. _`HTTPX`: https://docs.python-requests.org/en/master/
+.. _httpx.Response: https://docs.python-requests.org/en/master/api/#httpx.Response
+.. _httpx.Client: https://docs.python-requests.org/en/master/api/#request-sessions

--- a/sphinx/source/user_guide.rst
+++ b/sphinx/source/user_guide.rst
@@ -7,18 +7,6 @@ User Guide
 This is a topical guide to general API client usage. :ref:`module_reference`
 has in-depth documentation on client classes and methods.
 
-Installation
-------------
-If ``pip`` is available, it can be installed via:
-
-.. code-block:: shell
-
-    pip install pdpyras
-
-Alternately, if the dependencies (Requests_ and "deprecation" Python libraries)
-have been installed locally, one can download ``pdpyras.py`` into the directory
-where it will be used.
-
 Authentication
 --------------
 The first step is to construct a session object. The first argument to the

--- a/sphinx/source/user_guide.rst
+++ b/sphinx/source/user_guide.rst
@@ -766,7 +766,7 @@ the configured retry limits are reached in the underlying HTTP request methods.
 .. References:
 .. -----------
 
-.. _`HTTPX`: https://docs.python-requests.org/en/master/
+.. _`HTTPX`: https://www.python-httpx.org/
  .. _`Errors`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTYz-errors
 .. _`Events API v2`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgw-events-api-v2-overview
 .. _`PagerDuty API Reference`: https://developer.pagerduty.com/api-reference/

--- a/sphinx/source/user_guide.rst
+++ b/sphinx/source/user_guide.rst
@@ -40,7 +40,7 @@ constructor is the secret to use for accessing the API:
     # A special session class for the change events API (part of Events API v2):
     change_events_session = pdpyras.ChangeEventsAPISession(ROUTING_KEY)
 
-Session objects, being descendants of `requests.Session`_, can also be used as
+Session objects, being descendants of `httpx.Client`_, can also be used as
 context managers. For example:
 
 .. code-block:: python
@@ -232,14 +232,14 @@ Events API v2
 
 Generic Client Features
 -----------------------
-Generally, all of the features of `requests.Session`_ are available to the user
+Generally, all of the features of `httpx.Client`_ are available to the user
 as they would be if using the Requests Python library directly, since
 :class:`pdpyras.PDSession` and its subclasses for the REST/Events APIs are
 descendants of it. 
 
 The ``get``, ``post``, ``put`` and ``delete`` methods of REST/Events API
-session classes are similar to the analogous functions in `requests.Session`_.
-The arguments they accept are the same and they all return `requests.Response`_
+session classes are similar to the analogous functions in `httpx.Client`_.
+The arguments they accept are the same and they all return `httpx.Response`_
 objects.
 
 Any keyword arguments passed to the ``j*`` or ``r*`` methods will be passed
@@ -268,7 +268,7 @@ which case the URL at its ``self`` key will be used as the request target.
 
 Query Parameters
 ----------------
-As with `Requests`_, there is no need to compose the query string (everything
+As with `HTTPX`_, there is no need to compose the query string (everything
 that will follow ``?`` in the URL). Simply set the ``params`` keyword argument
 to a dictionary, and each of the key/value pairs will be serialized to the
 query string in the final URL of the request:
@@ -308,7 +308,7 @@ To set the request body in a post or put request, pass as the ``json`` keyword
 argument an object that will be JSON-encoded as the body.
 
 To obtain the response from the API, if using plain ``get``, ``post``, ``put``
-or ``delete``, use the returned `requests.Response`_ object. That object's
+or ``delete``, use the returned `httpx.Response`_ object. That object's
 ``json()`` method will return the result of JSON-decoding the response body (it
 will typically of type ``dict``). Other metadata such as headers can also be
 obtained:
@@ -590,14 +590,14 @@ the ``default_from`` keyword argument when constructing the session initially.
 
 Error Handling
 --------------
-For any of the methods that do not return `requests.Response`_, when the API
+For any of the methods that do not return `httpx.Response`_, when the API
 responds with a non-success HTTP status, the method will raise a
 :class:`pdpyras.PDClientError` exception. This way, these methods can always be
 expected to return the same structure of data based on the API being used, and
 there is no need to differentiate between the response schema for a successful
 request and one for an error response.
 
-The exception class has the `requests.Response`_ object as its ``response``
+The exception class has the `httpx.Response`_ object as its ``response``
 property whenever the exception pertains to a HTTP error. One can thus define
 specialized error handling logic in which the REST API response data (i.e.
 headers, code and body) are available in the catching scope.
@@ -709,7 +709,7 @@ will immediately raise ``pdpyras.PDClientError``; this is a non-transient error
 caused by an invalid credential.
 
 For all other success or error statuses, the underlying request method in the
-client will return the `requests.Response`_ object.
+client will return the `httpx.Response`_ object.
 
 Exponential Cooldown
 ********************
@@ -750,7 +750,7 @@ supersede the maximum number of retries for any status defined in
 :attr:`pdpyras.PDSession.retry` if it is lower.
 
 Low-level HTTP request functions in client classes, i.e. ``get``, will return
-`requests.Response`_ objects when they run out of retries. Higher-level
+`httpx.Response`_ objects when they run out of retries. Higher-level
 functions that require a success status response, i.e.
 :attr:`pdpyras.APISession.list_all` and
 :attr:`pdpyras.EventsAPISession.trigger`, will raise exceptions that include
@@ -778,11 +778,11 @@ the configured retry limits are reached in the underlying HTTP request methods.
 .. References:
 .. -----------
 
-.. _`Requests`: https://docs.python-requests.org/en/master/
+.. _`HTTPX`: https://docs.python-requests.org/en/master/
  .. _`Errors`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTYz-errors
 .. _`Events API v2`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgw-events-api-v2-overview
 .. _`PagerDuty API Reference`: https://developer.pagerduty.com/api-reference/
 .. _`REST API v2`: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTUw-rest-api-v2-overview
 .. _`setuptools`: https://pypi.org/project/setuptools/
-.. _requests.Response: https://docs.python-requests.org/en/master/api/#requests.Response
-.. _requests.Session: https://docs.python-requests.org/en/master/api/#request-sessions
+.. _httpx.Response: https://docs.python-requests.org/en/master/api/#httpx.Response
+.. _httpx.Client: https://docs.python-requests.org/en/master/api/#request-sessions

--- a/sphinx/source/user_guide.rst
+++ b/sphinx/source/user_guide.rst
@@ -99,7 +99,7 @@ and having them represented as a dictionary object using three different methods
         print(user['id'], user['email'], user['name'])
 
 **Pagination with query parameters:** set the ``params`` keyword argument, which is 
-converted to URL query parameters by Requests_:
+converted to URL query parameters by HTTPX_:
 
 .. code-block:: python
 
@@ -221,7 +221,7 @@ Events API v2
 Generic Client Features
 -----------------------
 Generally, all of the features of `httpx.Client`_ are available to the user
-as they would be if using the Requests Python library directly, since
+as they would be if using the HTTPX Python library directly, since
 :class:`pdpyras.PDSession` and its subclasses for the REST/Events APIs are
 descendants of it. 
 
@@ -231,11 +231,11 @@ The arguments they accept are the same and they all return `httpx.Response`_
 objects.
 
 Any keyword arguments passed to the ``j*`` or ``r*`` methods will be passed
-through to the analogous method in Requests_, though in some cases the
+through to the analogous method in HTTPX_, though in some cases the
 arguments (i.e. ``json``) are first modified.
 
 For documentation on any generic HTTP client features that are available, refer
-to the Requests_ documentation.
+to the HTTPX_ documentation.
 
 URLs
 ----
@@ -313,7 +313,7 @@ will be the full body of the response from the API after JSON-decoding, and
 the ``json`` keyword argument is not modified.
 
 When using the ``r*`` methods, the ``json`` keyword argument is modified before
-sending to Requests_, if necessary, to encapsulate the body inside an entity
+sending to HTTPX_, if necessary, to encapsulate the body inside an entity
 wrapper.  The response is the decoded body after unwrapping, if the API
 endpoint returns wrapped entities. For more details, refer to :ref:`wrapping`.
 

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -16,6 +16,10 @@ from unittest.mock import Mock, MagicMock, patch, call
 
 import pdpyras
 
+def assertDictContainsSubset(self, dict1, dict2):
+    self.assertTrue(dict1, dict2, "First dict is not a subset of the second. "\
+        "Keys (1): "+", ".join(dict1.keys())+"; Keys (2): "+", ".join(dict2.keys()))
+
 class Session(object):
     """
     Python reqeusts.Session mockery class
@@ -718,7 +722,7 @@ class APISessionTest(unittest.TestCase):
             request.assert_called()
             req_call = request.mock_calls[0]
             self.assertEqual(req_call.args, ('GET', 'https://api.pagerduty.com/users'))
-            self.assertDictContainsSubset(
+            assertDictContainsSubset(self,
                 {
                     'params': user_query,
                     'stream': False,
@@ -738,7 +742,7 @@ class APISessionTest(unittest.TestCase):
             request.assert_called()
             req_call = request.mock_calls[0]
             self.assertEqual(req_call.args, ('GET', 'https://api.pagerduty.com/users'))
-            self.assertDictContainsSubset(
+            assertDictContainsSubset(self,
                 {
                     'params': modified_user_query,
                     'stream': False,
@@ -761,7 +765,7 @@ class APISessionTest(unittest.TestCase):
                 req_call.args, 
                 ('POST', 'https://api.pagerduty.com/users/PD6LYSO/future_endpoint')
             )
-            self.assertDictContainsSubset(
+            assertDictContainsSubset(self,
                 {
                     'headers': headers_special,
                     'json': {'user': user},

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -700,7 +700,6 @@ class APISessionTest(unittest.TestCase):
                 'GET',
                 'https://api.pagerduty.com/users',
                 timeout=pdpyras.TIMEOUT,
-                stream=False
             )
             request.reset_mock()
 
@@ -711,7 +710,6 @@ class APISessionTest(unittest.TestCase):
                 'POST',
                 'https://api.pagerduty.com/users',
                 json={'user':user},
-                stream=False,
                 timeout=pdpyras.TIMEOUT
             )
             request.reset_mock()
@@ -726,7 +724,6 @@ class APISessionTest(unittest.TestCase):
             assertDictContainsSubset(self,
                 {
                     'params': user_query,
-                    'stream': False,
                     'timeout': pdpyras.TIMEOUT
                 },
                 req_call.kwargs
@@ -746,7 +743,6 @@ class APISessionTest(unittest.TestCase):
             assertDictContainsSubset(self,
                 {
                     'params': modified_user_query,
-                    'stream': False,
                     'timeout': pdpyras.TIMEOUT
                 },
                 req_call.kwargs
@@ -770,7 +766,6 @@ class APISessionTest(unittest.TestCase):
                 {
                     'headers': headers_special,
                     'json': {'user': user},
-                    'stream': False,
                     'timeout': pdpyras.TIMEOUT,
                     'data': None
                 },

--- a/test_pdpyras.py
+++ b/test_pdpyras.py
@@ -17,8 +17,9 @@ from unittest.mock import Mock, MagicMock, patch, call
 import pdpyras
 
 def assertDictContainsSubset(self, dict1, dict2):
-    self.assertTrue(dict1, dict2, "First dict is not a subset of the second. "\
-        "Keys (1): "+", ".join(dict1.keys())+"; Keys (2): "+", ".join(dict2.keys()))
+    self.assertTrue(dict1.items() <= dict2.items(), "First dict is not a subset"\
+        "of the second. Keys (1): "+", ".join(dict1.keys())+"; Keys (2): "+\
+        ", ".join(dict2.keys()))
 
 class Session(object):
     """
@@ -806,7 +807,7 @@ class APISessionTest(unittest.TestCase):
             with patch.object(pdpyras.time, 'sleep') as sleep:
                 # Test getting a connection error and succeeding the final time.
                 returns = [
-                    pdpyras.HTTPError("D'oh!")
+                    pdpyras.RequestError("D'oh!")
                 ]*sess.max_network_attempts
                 returns.append(Response(200, json.dumps({'user': user})))
                 request.side_effect = returns
@@ -824,7 +825,7 @@ class APISessionTest(unittest.TestCase):
                 # Now test handling a non-transient error when the client
                 # library itself hits odd issues that it can't handle, i.e.
                 # network, and that the raised exception includes context:
-                raises = [pdpyras.RequestException("D'oh!")]*(
+                raises = [pdpyras.RequestError("D'oh!")]*(
                     sess.max_network_attempts+1)
                 request.side_effect = raises
                 try:


### PR DESCRIPTION
## Justification

Long-term, we are looking to add support for thread safety, i.e. to fulfill #132. This requires switching the HTTP client on which pdpyras is based to one that is thread-safe. HTTPX is thread-safe and provides an interface that is very similar to that of Requests, and so minimal changes will be necessary in order to adopt it. Moreover, it optionally supports HTTP/2 which gives us the option of supporting that protocol in the future as well. Finally, [allegations](https://blog.ian.stapletoncordas.co/2024/02/a-retrospective-on-requests#internal-design-may-be-artful-but-it-s-not-good-software) regarding how the maintainers of Requests have responded to responsible security disclosures give us pause, and compel us to switch out the base HTTP client for the benefit of PagerDuty customers' security.

## Summary of Changes

* Replace `requests.Session` with `httpx.Client` and `requests.Response` with `httpx.Response`
* Deprecate the "prepare_headers" method, which was not needed and complicated integration with HTTPX
* Add a new "default_headers" property to take its place

## To-do

* [x] Validate that sending GET requests with `content-type: application/json` won't mess with how query parameters are interpreted and thus that it is safe to proceed with the simplification that pays off a bit of tech debt
* [x] Enumerate all the possible exception classes that could be raised by httpx and its dependencies and update the error handling logic to recognize them
* [x] Write down the full list of deprecations and breaking changes (if any)
* [ ] Test the various functions of the new client using a live key 
* [ ] Add a basic integration test to CircleCI (could be any single Python version, it needn't be all of them) using the same API key as publicly given for demo purposes in the developer documentation 